### PR TITLE
manifest: adding meta-virt support

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -15,6 +15,7 @@
   <project remote="yocto" name="meta-java" revision="a73939323984fca1e919d3408d3301ccdbceac9c" path="repos/meta-java"/>
   <project remote="yocto" name="meta-selinux" revision="jethro" path="repos/meta-selinux"/>
   <project remote="yocto" name="meta-intel" revision="jethro" path="repos/meta-intel"/>
+  <project remote="yocto" name="meta-virtualization" revision="jethro" path="repos/meta-virtualization"/>
 
   <project remote="github" name="apertussolutions/meta-servicevm" revision="master" force-path="yes" path="repos/meta-servicevm"/>
   <project remote="github" name="openxt/meta-openxt-haskell-platform" revision="master" force-path="yes" path="repos/meta-openxt-haskell-platform"/>

--- a/files/layers.openxt
+++ b/files/layers.openxt
@@ -10,3 +10,4 @@ meta-openembedded/meta-python
 meta-java
 meta-selinux
 meta-intel
+meta-metavirtualization


### PR DESCRIPTION
Update the manifest and the layers definition to account for move to
meta-virt