### PR TITLE
files: disable seccomp due to 32bit

### DIFF
--- a/files/host-env
+++ b/files/host-env
@@ -141,6 +141,7 @@ oxt_build() {
     fi
 
     docker run --rm -it \
+	--security-opt seccomp=unconfined \
         -v "${OPENXT_DIR}:/home/${user}/openxt" \
         -v ${HOME}/.ssh:/home/${user}/.ssh \
         -v ${HOME}/.gitconfig:/home/${user}/.gitconfig \


### PR DESCRIPTION
The seccomp policy breaks getcontext for 32bit binaries. See the link
below for details.

https://github.com/moby/moby/issues/28162

Signed-off-by: Daniel P. Smith <dpsmith@apertussolutions.com>