### PR TITLE
gen-iso: a utility script to generate an iso image

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,16 @@ directory.
 This script is used in conjunction with **gen-release**. Pass the same
 parameters and the release package will be signed with the build certs.
 
+
+##### **gen-iso** -n *{build_id}* -r *{release_tag}*
+
+This script is a wrapper around gen-release, sign-oxt-repo, and a couple
+of other commands to prepare the final .iso image file. It takes two options
+   -n : the build id
+   -r : the  release tag
+
+The genearted iso file is placed under build-<BUILD_ID>/release/<RELEASE_TAG>
+
 ### Build Environment
 
 The build environmnet is a pseudo-ephemeral environment that is Docker

--- a/files/gen-iso
+++ b/files/gen-iso
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 ATCorp
+#
+# Contributions by Jafar Al-Gharaibeh
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+#
+
+# Usage: usage <exit-code>
+# Display the usage of this script.
+usage() {
+    echo "Usage: gen-iso [options]"
+    echo "Helper script to create an OpenXT image."
+    echo ""
+    echo "Options:"
+    echo "  -n      build number."
+    echo "  -r      release tag."
+    echo "  -h      display this help and exit."
+    echo ""
+    exit $1
+}
+
+
+
+# A POSIX variable
+OPTIND=1         # Reset in case getopts has been used previously in the shell.
+
+# Parse options.
+while getopts ":hn:r:" opt; do
+    case $opt in
+        h|\?)  usage 0 ;;
+
+        :)  echo "Option \`${OPTARG}' is missing an argument." >&2
+            usage 1
+            ;;
+        \?) echo "Unknown option \`${OPTARG}'." >&2
+            usage 1
+            ;;
+	    
+        n)  build_id=$OPTARG;;
+        r)  release_tag=$OPTARG;;
+
+    esac
+done
+
+
+shift $((OPTIND-1))
+
+[ "${1:-}" = "--" ] && shift
+
+
+echo ""
+echo "Creating a release iso with"
+echo "   build id   : $build_id"
+echo "   release tag: $release_tag"
+echo ""
+
+if [ ! -d "./build-${build_id}" ]; then
+    echo "ERROR: build-${build_id} does not exist"
+    exit 1
+fi
+
+BUILD_ID=${build_id}
+RELEASE_TAG=${release_tag}
+
+./bin/gen-release ${BUILD_ID} "build-${BUILD_ID}/release/${RELEASE_TAG}"
+
+./bin/sign-oxt-repo ${BUILD_ID} "build-${BUILD_ID}/release/${RELEASE_TAG}"
+
+genisoimage -o "build-${BUILD_ID}/release/${RELEASE_TAG}"/installer.iso -b "isolinux/isolinux.bin" -c "isolinux/boot.cat" -no-emul-boot -boot-load-size 4 -boot-info-table -r -J -l -V "OpenXT-9.0.${RELEASE_TAG}" -f -quiet -m ipk "build-${BUILD_ID}/release/${RELEASE_TAG}"
+
+isohybrid "build-${BUILD_ID}/release/${RELEASE_TAG}"/installer.iso


### PR DESCRIPTION
   This script is a wrapper around gen-release, sign-oxt-repo, and a couple
   other commands to prepare the final .iso image file. It takes two options
   -n : the build id
   -r : the  release tag

The genearted iso file is placed under build-<BUILD_ID>/release/<RELEASE_TAG>

Signed-off-by: Jafar Al-Gharaibeh <jafar@atcorp.com>