### PR TITLE
templates: Add stable-9 manifest and templates.

### DIFF
--- a/stable-9.xml
+++ b/stable-9.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <default revision="stable-9" sync-j="1"/>
+
+  <remote fetch="http://git.yoctoproject.org/git" name="yocto"/>
+  <remote fetch="git://git.openembedded.org" name="oe"/>
+  <remote fetch="https://github.com" name="github"/>
+
+  <project remote="github" name="openembedded/bitbake" revision="1.34" path="layers/bitbake"/>
+  <project remote="github" name="openembedded/openembedded-core" revision="pyro" path="layers/openembedded-core"/>
+  <project remote="github" name="openembedded/meta-openembedded" revision="pyro" path="layers/meta-openembedded"/>
+
+  <project remote="yocto" name="meta-intel" revision="pyro" path="layers/meta-intel"/>
+  <project remote="yocto" name="meta-java" revision="pyro" path="layers/meta-java"/>
+  <project remote="yocto" name="meta-selinux" revision="b1dac7e2b26f869c991c6492aa7fa18eaa4b47f6" path="layers/meta-selinux"/>
+  <project remote="yocto" name="meta-virtualization" revision="pyro" path="layers/meta-virtualization"/>
+
+  <project remote="github" name="openxt/meta-openxt-ocaml-platform" path="layers/meta-openxt-ocaml-platform"/>
+  <project remote="github" name="openxt/meta-openxt-haskell-platform" path="layers/meta-openxt-haskell-platform"/>
+  <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe">
+      <linkfile dest="bin" src="../../.repo/manifests/bin"/>
+      <linkfile dest="templates" src="../../.repo/manifests/templates"/>
+  </project>
+
+  <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
+  <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>
+  <project remote="github" name="openxt/icbinn" path="openxt/icbinn"/>
+  <project remote="github" name="openxt/idl" path="openxt/idl"/>
+  <project remote="github" name="openxt/input" path="openxt/input"/>
+  <project remote="github" name="openxt/installer" path="openxt/installer"/>
+  <project remote="github" name="openxt/libedid" path="openxt/libedid"/>
+  <project remote="github" name="openxt/libxcdbus" path="openxt/libxcdbus"/>
+  <project remote="github" name="openxt/libxenbackend" path="openxt/libxenbackend"/>
+  <project remote="github" name="openxt/manager" path="openxt/manager"/>
+  <project remote="github" name="openxt/network" path="openxt/network"/>
+  <project remote="github" name="openxt/pv-linux-drivers" path="openxt/pv-linux-drivers"/>
+  <project remote="github" name="openxt/resized" path="openxt/resized"/>
+  <project remote="github" name="openxt/sync-client" path="openxt/sync-client"/>
+  <project remote="github" name="openxt/sync-wui" path="openxt/sync-wui"/>
+  <project remote="github" name="openxt/surfman" path="openxt/surfman"/>
+  <project remote="github" name="openxt/toolstack" path="openxt/toolstack"/>
+  <project remote="github" name="openxt/toolstack-data" path="openxt/toolstack-data"/>
+  <project remote="github" name="openxt/uid" path="openxt/uid"/>
+  <project remote="github" name="openxt/v4v" path="openxt/v4v"/>
+  <project remote="github" name="openxt/vusb-daemon" path="openxt/vusb-daemon"/>
+  <project remote="github" name="openxt/xblanker" path="openxt/xblanker"/>
+  <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
+  <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
+  <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
+      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
+  </project>
+
+</manifest>
+

--- a/templates/master/openxt.conf
+++ b/templates/master/openxt.conf
@@ -5,7 +5,7 @@ OPENXT_BUILD_ID="0"
 OPENXT_VERSION="9.0.0"
 # Name Refering to the release (purely cosmetic).
 # https://randomword.com/
-OPENXT_RELEASE="gabion"
+OPENXT_RELEASE="agrypnotic"
 # List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
 OPENXT_UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2 9.0.0"
 # OpenXT branch name.

--- a/templates/stable-9/bblayers.conf
+++ b/templates/stable-9/bblayers.conf
@@ -1,0 +1,22 @@
+# LAYER_CONF_VERSION is increased each time conf/bblayers.conf changes
+# incompatibly
+
+LCONF_VERSION = "7"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+BBLAYERS ?= " \
+  ${LAYERS_DIR}/openembedded-core/meta \
+  ${LAYERS_DIR}/meta-openembedded/meta-oe \
+  ${LAYERS_DIR}/meta-openembedded/meta-python \
+  ${LAYERS_DIR}/meta-openembedded/meta-networking \
+  ${LAYERS_DIR}/meta-openembedded/meta-gnome \
+  ${LAYERS_DIR}/meta-openembedded/meta-xfce \
+  ${LAYERS_DIR}/meta-intel \
+  ${LAYERS_DIR}/meta-java \
+  ${LAYERS_DIR}/meta-selinux \
+  ${LAYERS_DIR}/xenclient-oe \
+  ${LAYERS_DIR}/meta-openxt-ocaml-platform \
+  ${LAYERS_DIR}/meta-openxt-haskell-platform \
+  ${LAYERS_DIR}/meta-virtualization \
+  "

--- a/templates/stable-9/build-manifest
+++ b/templates/stable-9/build-manifest
@@ -1,0 +1,12 @@
+# Format:
+# <MACHINE> <target-image-recipe>
+#
+xenclient-dom0 xenclient-initramfs-image
+openxt-installer xenclient-installer-image
+openxt-installer xenclient-installer-part2-image
+upgrade-compat xenclient-upgrade-compat-image
+xenclient-stubdomain xenclient-stubdomain-initramfs-image
+xenclient-dom0 xenclient-dom0-image
+xenclient-uivm xenclient-uivm-image
+xenclient-ndvm xenclient-ndvm-image
+xenclient-syncvm xenclient-syncvm-image

--- a/templates/stable-9/images-manifest
+++ b/templates/stable-9/images-manifest
@@ -1,0 +1,15 @@
+# Format:
+# <MACHINE> <image-id> <source-label> <image-type> <destination-label> <mount-point>
+# MACHINE: Machine name as seen by Bitbake/OE
+# image-id: Image identifier, used in XC-PACKAGES metadata.
+# source-label: Label used to name the built image by Bitbake, usually the name of the recipe that built the image.
+# image-type: The format used for this image.
+# destination-label: Label used to name the image in the destination repository hierarchy (usually <image-id>-rootfs).
+# mount-point: Mount point of the image when deployed on a target.
+#
+openxt-installer control xenclient-installer-part2-image tar.bz2 control /
+upgrade-compat upgrade-compat xenclient-upgrade-compat-image ext3.gz upgrade-compat-rootfs /
+xenclient-dom0 dom0 xenclient-dom0-image ext3.gz dom0-rootfs /
+xenclient-uivm uivm xenclient-uivm-image ext3.vhd.gz uivm-rootfs /storage/uivm
+xenclient-ndvm ndvm xenclient-ndvm-image ext3.disk.vhd.gz ndvm-rootfs /storage/ndvm
+xenclient-syncvm syncvm xenclient-syncvm-image ext3.vhd.gz syncvm-rootfs /storage/syncvm

--- a/templates/stable-9/local.conf
+++ b/templates/stable-9/local.conf
@@ -1,0 +1,99 @@
+# CONF_VERSION is increased each time conf/ changes incompatibly
+CONF_VERSION = "1"
+
+# Removes source after build.
+#INHERIT += "rm_work"
+#RM_WORK_EXCLUDE += ""
+
+# Don't generate the mirror tarball for SCM repos, the snapshot is enough
+BB_GENERATE_MIRROR_TARBALLS = "0"
+
+#
+# Parallelism Options
+#
+# These two options control how much parallelism BitBake should use.
+# The first option determines how many tasks bitbake should run in parallel:
+# Default to setting automatically based on cpu count
+BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"
+#
+# The second option controls how many processes make should run in parallel
+# when running compile tasks:
+# Default to setting automatically based on cpu count
+PARALLEL_MAKE ?= "-j ${@oe.utils.cpu_count()}"
+
+
+# Detailed build performance log data in tmp/buildstats.
+#INHERIT += "buildstats"
+
+#
+# Shared-state files from other locations
+#
+# Shared state files are prebuilt cache data objects which can used to
+# accelerate build time. This variable can be used to configure the system to
+# search other mirror locations for these objects before it builds the data
+# itself.
+#
+# This can be a filesystem directory, or a remote url such as http or ftp.
+# These would contain the sstate-cache results from previous builds (possibly
+# from other machines). This variable works like fetcher MIRRORS/PREMIRRORS
+# and points to the cache locations to check for the shared objects.
+#SSTATE_MIRRORS ?= "\
+#file://.* http://someserver.tld/share/sstate/ \n \
+#file://.* file:///some/local/dir/sstate/"
+
+#SSTATE_MIRRORS ?= "\
+#file://.* http://dominion.thruhere.net/angstrom/sstate-mirror/ \n "
+
+SSTATE_DUPWHITELIST += "${DEPLOY_DIR}/licences"
+
+# enable PR service on build machine itself its good for a case when this is
+# the only builder generating the feeds
+#
+PRSERV_HOST = "localhost:0"
+
+# Common URL translations.
+MIRRORS += " \
+    http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
+    http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
+    git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+"
+
+# TODO: This probably belongs to the xenclient-oe layer.
+REPO_PROD_CACERT="${OPENXT_CERTS_DIR}/prod-cacert.pem"
+REPO_DEV_CACERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_CERT="${OPENXT_CERTS_DIR}/dev-cacert.pem"
+REPO_DEV_SIGNING_DEV="${OPENXT_CERTS_DIR}/dev-cakey.pem"
+
+# If ENABLE_BINARY_LOCALE_GENERATION is set to "1", you can limit locales
+# generated to the list provided by GLIBC_GENERATE_LOCALES. This is huge
+# time-savior for developmental builds.
+ENABLE_BINARY_LOCALE_GENERATION = "1"
+# Specifies the list of GLIBC locales to generate to save some build time.
+# http://www.yoctoproject.org/docs/current/ref-manual/ref-manual.html#var-GLIBC_GENERATE_LOCALES
+GLIBC_GENERATE_LOCALES += " \
+    de_DE.UTF-8 \
+    en_US.UTF-8 \
+    en_GB.UTF-8 \
+    es_ES.UTF-8 \
+    fr_FR.UTF-8 \
+    ja_JP.UTF-8 \
+    zh_CN.UTF-8 \
+"
+
+# Should be changed for remote feed.
+XENCLIENT_PACKAGE_FEED_URI ?= "file:///storage/ipk"
+
+require openxt.conf
+# xenclient-feed-configs. It requires a bunch of things:
+XENCLIENT_BUILD = "${OPENXT_BUILD_ID}"
+XENCLIENT_BUILD_BRANCH = "${OPENXT_BUILD_BRANCH}"
+XENCLIENT_RELEASE = "${OPENXT_RELEASE}"
+XENCLIENT_VERSION = "${OPENXT_VERSION}"
+include openxt-build-date.conf
+XENCLIENT_BUILD_DATE = "${OPENXT_BUILD_DATE}"
+
+# OpenXT: Set SELinux enforcing (Debug)
+DEFAULT_ENFORCING = "permissive"
+
+# OpenXT: Enable debugging tweaks.
+EXTRA_IMAGE_FEATURES += "debug-tweaks"

--- a/templates/stable-9/openxt.conf
+++ b/templates/stable-9/openxt.conf
@@ -1,0 +1,12 @@
+# OpenXT build ID.
+# Numeral: incremental, starting from the given number.
+OPENXT_BUILD_ID="0"
+# OpenXT version number. This will influence the upgrade path.
+OPENXT_VERSION="9.0.0"
+# Name Refering to the release (purely cosmetic).
+# https://randomword.com/
+OPENXT_RELEASE="gabion"
+# List of OpenXT versions that can be upgraded to this one (${OPENXT_VERSION}).
+OPENXT_UPGRADEABLE_RELEASES="8.0.0 8.0.1 8.0.2 9.0.0"
+# OpenXT branch name.
+OPENXT_BUILD_BRANCH="stable-9"


### PR DESCRIPTION
3 repositories are no longer used in stable-9:
- https://github.com/OpenXT/dm-agent ; Deprecated and no longer used.
- https://github.com/OpenXT/blktap3 ; Recipe switched to upstream repository.
- https://github.com/OpenXT/ocaml ; Entirely replaced with recent xl/libxl work.

Pick a random new codename for master. This is purely cosmetic anyway.