### PR TITLE
templates: stable-8 requires Debian archive.

### DIFF
--- a/templates/stable-8/local.conf
+++ b/templates/stable-8/local.conf
@@ -56,6 +56,7 @@ MIRRORS += " \
     http://code.coreboot.org/p/seabios/downloads/.*     https://www.seabios.org/downloads/ \n \
     http://www.seabios.org/downloads/.*                 https://www.seabios.org/downloads/ \n \
     git://anonscm.debian.org/collab-maint/ltrace.git    git://github.com/sparkleholic/ltrace.git \n \
+    ${DEBIAN_MIRROR}                                    http://archive.debian.org/debian/pool/ \n \
 "
 
 # TODO: This probably belongs to the xenclient-oe layer.


### PR DESCRIPTION
console-setup 1.88 has been moved to archive repositories.

In general adding the archives in `MIRRORS` for `DEBIAN_MIRROR` fetched packages could avoid futur build failures.