### PR TITLE
manifest: Add argo repository and bump master version number.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -33,6 +33,7 @@
   <project remote="github" name="openxt/libedid" path="openxt/libedid"/>
   <project remote="github" name="openxt/libxcdbus" path="openxt/libxcdbus"/>
   <project remote="github" name="openxt/libxenbackend" path="openxt/libxenbackend"/>
+  <project remote="github" name="openxt/linux-xen-argo" path="openxt/linux-xen-argo"/>
   <project remote="github" name="openxt/manager" path="openxt/manager"/>
   <project remote="github" name="openxt/network" path="openxt/network"/>
   <project remote="github" name="openxt/ocaml" path="openxt/ocaml"/>
@@ -44,7 +45,6 @@
   <project remote="github" name="openxt/toolstack" path="openxt/toolstack"/>
   <project remote="github" name="openxt/toolstack-data" path="openxt/toolstack-data"/>
   <project remote="github" name="openxt/uid" path="openxt/uid"/>
-  <project remote="github" name="openxt/v4v" path="openxt/v4v"/>
   <project remote="github" name="openxt/vusb-daemon" path="openxt/vusb-daemon"/>
   <project remote="github" name="openxt/xblanker" path="openxt/xblanker"/>
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>

--- a/stable-9.xml
+++ b/stable-9.xml
@@ -32,6 +32,7 @@
   <project remote="github" name="openxt/libedid" path="openxt/libedid"/>
   <project remote="github" name="openxt/libxcdbus" path="openxt/libxcdbus"/>
   <project remote="github" name="openxt/libxenbackend" path="openxt/libxenbackend"/>
+  <project remote="github" name="openxt/linux-xen-argo" path="openxt/linux-xen-argo"/>
   <project remote="github" name="openxt/manager" path="openxt/manager"/>
   <project remote="github" name="openxt/network" path="openxt/network"/>
   <project remote="github" name="openxt/pv-linux-drivers" path="openxt/pv-linux-drivers"/>
@@ -42,7 +43,6 @@
   <project remote="github" name="openxt/toolstack" path="openxt/toolstack"/>
   <project remote="github" name="openxt/toolstack-data" path="openxt/toolstack-data"/>
   <project remote="github" name="openxt/uid" path="openxt/uid"/>
-  <project remote="github" name="openxt/v4v" path="openxt/v4v"/>
   <project remote="github" name="openxt/vusb-daemon" path="openxt/vusb-daemon"/>
   <project remote="github" name="openxt/xblanker" path="openxt/xblanker"/>
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>

--- a/templates/master/openxt.conf
+++ b/templates/master/openxt.conf
@@ -2,7 +2,7 @@
 # Numeral: incremental, starting from the given number.
 OPENXT_BUILD_ID="0"
 # OpenXT version number. This will influence the upgrade path.
-OPENXT_VERSION="9.0.0"
+OPENXT_VERSION="10.0.0"
 # Name Refering to the release (purely cosmetic).
 # https://randomword.com/
 OPENXT_RELEASE="agrypnotic"


### PR DESCRIPTION
- Stable-9 and master switched from using V4V to Argo. The drivers now live in a separate layer that needs to be added to the versions manifests.
- master should now be version `10.0.0` following `stable-9` branching.