### PR TITLE
default: Remove defunct repositories.

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -21,7 +21,6 @@
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
 
   <project remote="github" name="apertussolutions/bordel" path="openxt/bordel"/>
-  <project remote="github" name="openxt/dm-agent" path="openxt/dm-agent"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
   <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>
   <project remote="github" name="openxt/icbinn" path="openxt/icbinn"/>
@@ -34,7 +33,6 @@
   <project remote="github" name="openxt/linux-xen-argo" path="openxt/linux-xen-argo"/>
   <project remote="github" name="openxt/manager" path="openxt/manager"/>
   <project remote="github" name="openxt/network" path="openxt/network"/>
-  <project remote="github" name="openxt/ocaml" path="openxt/ocaml"/>
   <project remote="github" name="openxt/pv-linux-drivers" path="openxt/pv-linux-drivers"/>
   <project remote="github" name="openxt/resized" path="openxt/resized"/>
   <project remote="github" name="openxt/sync-client" path="openxt/sync-client"/>


### PR DESCRIPTION
The default manifest still lists two repositories no longer pulled by
the OpenXT layers recipes:
- https://github.com/OpenXT/ocaml (removed in stable-7)
- https://github.com/OpenXT/dm-agent (removed in stable-9)