### PR TITLE
default: Use Zeus branches for OE repositories

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -7,14 +7,14 @@
   <remote fetch="git://git.openembedded.org" name="oe"/>
   <remote fetch="https://github.com" name="github"/>
 
-  <project remote="github" name="openembedded/bitbake" revision="1.34" path="layers/bitbake"/>
-  <project remote="github" name="openembedded/openembedded-core" revision="pyro" path="layers/openembedded-core"/>
-  <project remote="github" name="openembedded/meta-openembedded" revision="pyro" path="layers/meta-openembedded"/>
+  <project remote="github" name="openembedded/bitbake" revision="1.44" path="layers/bitbake"/>
+  <project remote="github" name="openembedded/openembedded-core" revision="zeus" path="layers/openembedded-core"/>
+  <project remote="github" name="openembedded/meta-openembedded" revision="zeus" path="layers/meta-openembedded"/>
 
-  <project remote="yocto" name="meta-intel" revision="pyro" path="layers/meta-intel"/>
-  <project remote="yocto" name="meta-java" revision="pyro" path="layers/meta-java"/>
-  <project remote="yocto" name="meta-selinux" revision="b1dac7e2b26f869c991c6492aa7fa18eaa4b47f6" path="layers/meta-selinux"/>
-  <project remote="yocto" name="meta-virtualization" revision="pyro" path="layers/meta-virtualization"/>
+  <project remote="yocto" name="meta-intel" revision="zeus" path="layers/meta-intel"/>
+  <project remote="yocto" name="meta-java" revision="zeus" path="layers/meta-java"/>
+  <project remote="yocto" name="meta-selinux" revision="zeus" path="layers/meta-selinux"/>
+  <project remote="yocto" name="meta-virtualization" revision="zeus" path="layers/meta-virtualization"/>
 
   <project remote="github" name="openxt/meta-openxt-ocaml-platform" path="layers/meta-openxt-ocaml-platform"/>
   <project remote="github" name="openxt/meta-openxt-haskell-platform" path="layers/meta-openxt-haskell-platform"/>
@@ -34,7 +34,6 @@
   <project remote="github" name="openxt/manager" path="openxt/manager"/>
   <project remote="github" name="openxt/network" path="openxt/network"/>
   <project remote="github" name="openxt/pv-linux-drivers" path="openxt/pv-linux-drivers"/>
-  <project remote="github" name="openxt/resized" path="openxt/resized"/>
   <project remote="github" name="openxt/sync-client" path="openxt/sync-client"/>
   <project remote="github" name="openxt/sync-wui" path="openxt/sync-wui"/>
   <project remote="github" name="openxt/surfman" path="openxt/surfman"/>


### PR DESCRIPTION
OpenXT layers were upgraded to Zeus (OE 3.0). Change the default
manifest to reflect it.

Per OpenXT PR, this now requires a more recent container version
(recommended: Debian buster).