### PR TITLE
readme: add haskell dependency, drop docbook-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,13 +109,13 @@ bcc
 bin86
 curl
 cvs
-docbook-utils
 dosfstools
 genisoimage
 guilt
 iasl
 libelf-dev
 libncurses5-dev
+libncursesw5
 libsdl1.2-dev
 liburi-perl
 locales


### PR DESCRIPTION
Add libncursesw5 to compile Haskell's ghc 6.13 on Debian Buster.

Drop docbook-utils to reduce disk footprint, not used by OpenXT build.

Signed-off-by: Rich Persaud <rich.persaud@baesystems.com>