### PR TITLE
repo: Do not create the mirror symlink

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -47,9 +47,7 @@
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
   <project remote="github" name="openxt/blktap3" path="openxt/blktap3"/>
   <project remote="github" name="openxt/bats-suite" path="openxt/bats-suite"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>
 

--- a/pre-zeus.xml
+++ b/pre-zeus.xml
@@ -47,9 +47,7 @@
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
   <project remote="github" name="openxt/blktap3" path="openxt/blktap3"/>
   <project remote="github" name="openxt/bats-suite" path="openxt/bats-suite"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>
 

--- a/stable-6.xml
+++ b/stable-6.xml
@@ -44,9 +44,7 @@
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
   <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>
 

--- a/stable-7.xml
+++ b/stable-7.xml
@@ -48,9 +48,7 @@
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
   <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>
 

--- a/stable-8.xml
+++ b/stable-8.xml
@@ -49,8 +49,6 @@
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
   <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>

--- a/stable-9.xml
+++ b/stable-9.xml
@@ -46,9 +46,7 @@
   <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
   <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
   <project remote="github" name="openxt/xenfb2" path="openxt/xenfb2"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy">
-      <linkfile dest="mirror" src="../../.repo/projects/openxt/"/>
-  </project>
+  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
 
 </manifest>
 


### PR DESCRIPTION
repo since 1.13.12 checks for path out of scope for copyfile/lnkfile
nodes in the manifest:
https://gerrit.googlesource.com/git-repo/+/04122b7261319dae3abcaf0eb63af7ed937dc463

The manifest currently fail with:
```
error.ManifestInvalidPathError: <linkfile> invalid "src": ../../.repo/projects/openxt/: bad component: ..
```

#### Depends on:
- https://github.com/apertussolutions/bordel/pull/16