### PR TITLE
default: use layer revisions

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -24,34 +24,5 @@
   <project remote="gitlab" name="vglass/meta-vglass" path="layers/meta-vglass"/>
 
   <project remote="github" name="apertussolutions/bordel" path="openxt/bordel"/>
-  <project remote="github" name="openxt/icbinn" path="openxt/icbinn"/>
-  <project remote="github" name="openxt/idl" path="openxt/idl"/>
-  <project remote="github" name="openxt/installer" path="openxt/installer"/>
-  <project remote="github" name="openxt/libxcdbus" path="openxt/libxcdbus"/>
-  <project remote="github" name="openxt/libxenbackend" path="openxt/libxenbackend"/>
-  <project remote="github" name="openxt/linux-xen-argo" path="openxt/linux-xen-argo"/>
-  <project remote="github" name="openxt/manager" path="openxt/manager"/>
-  <project remote="github" name="openxt/network" path="openxt/network"/>
-  <project remote="github" name="openxt/pv-linux-drivers" path="openxt/pv-linux-drivers"/>
-  <project remote="github" name="openxt/sync-client" path="openxt/sync-client"/>
-  <project remote="github" name="openxt/sync-wui" path="openxt/sync-wui"/>
-  <project remote="github" name="openxt/toolstack" path="openxt/toolstack"/>
-  <project remote="github" name="openxt/toolstack-data" path="openxt/toolstack-data"/>
-  <project remote="github" name="openxt/uid" path="openxt/uid"/>
-  <project remote="github" name="openxt/vusb-daemon" path="openxt/vusb-daemon"/>
-  <project remote="github" name="openxt/xclibs" path="openxt/xclibs"/>
-  <project remote="github" name="openxt/xctools" path="openxt/xctools"/>
-  <project remote="github" name="openxt/blktap3" path="openxt/blktap3"/>
-  <project remote="github" name="openxt/bats-suite" path="openxt/bats-suite"/>
-  <project remote="github" name="openxt/xsm-policy" path="openxt/xsm-policy"/>
-
-  <project remote="gitlab" name="vglass/disman" path="openxt/disman"/>
-  <project remote="gitlab" name="vglass/glass" path="openxt/glass"/>
-  <project remote="gitlab" name="vglass/ivc" path="openxt/ivc"/>
-  <project remote="gitlab" name="vglass/openxtfb" path="openxt/openxtfb"/>
-  <project remote="gitlab" name="vglass/pv-display-helper" path="openxt/pv-display-helper"/>
-  <project remote="gitlab" name="vglass/xf86-video-openxtfb" path="openxt/xf86-video-openxtfb"/>
-  <project remote="gitlab" name="vglass/glassdrm" path="openxt/glassdrm"/>
-
 </manifest>
 


### PR DESCRIPTION
master will now fetch upstream repositories instead of local clones.
There is no need to mirror OpenXT sub-project repositories.