### PR TITLE
manifests: bordel has been transferred to OpenXT

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ layout__ for details.
 ```bash
    mkdir openxt-workspace
    cd openxt-workspace
-   repo init -u https://github.com/apertussolutions/openxt-manifest.git
+   repo init -u https://github.com/OpenXT/openxt-manifest.git
    repo sync
 ```
 

--- a/default.xml
+++ b/default.xml
@@ -23,6 +23,6 @@
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
   <project remote="gitlab" name="vglass/meta-vglass" path="layers/meta-vglass"/>
 
-  <project remote="github" name="apertussolutions/bordel" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" path="openxt/bordel"/>
 </manifest>
 

--- a/pre-zeus.xml
+++ b/pre-zeus.xml
@@ -20,7 +20,7 @@
   <project remote="github" name="openxt/meta-openxt-haskell-platform" revision="refs/tags/pre-zeus" path="layers/meta-openxt-haskell-platform"/>
   <project remote="github" name="openxt/xenclient-oe" revision="refs/tags/pre-zeus" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" path="openxt/bordel"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
   <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>
   <project remote="github" name="openxt/icbinn" path="openxt/icbinn"/>

--- a/stable-6.xml
+++ b/stable-6.xml
@@ -16,7 +16,7 @@
 
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" revision="master" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" revision="master" path="openxt/bordel"/>
   <project remote="github" name="openxt/dm-agent" path="openxt/dm-agent"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
   <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>

--- a/stable-7.xml
+++ b/stable-7.xml
@@ -20,7 +20,7 @@
   <project remote="github" name="openxt/meta-openxt-haskell-platform" path="layers/meta-openxt-haskell-platform"/>
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" revision="master" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" revision="master" path="openxt/bordel"/>
   <project remote="github" name="openxt/dm-agent" path="openxt/dm-agent"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
   <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>

--- a/stable-8.xml
+++ b/stable-8.xml
@@ -20,7 +20,7 @@
   <project remote="github" name="openxt/meta-openxt-ocaml-platform" force-path="yes" path="layers/meta-openxt-ocaml-platform"/>
   <project remote="github" name="openxt/xenclient-oe" force-path="yes" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" revision="master" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" revision="master" path="openxt/bordel"/>
   <project remote="github" name="openxt/blktap3" path="openxt/blktap3"/>
   <project remote="github" name="openxt/dm-agent" path="openxt/dm-agent"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>

--- a/stable-9.xml
+++ b/stable-9.xml
@@ -20,7 +20,7 @@
   <project remote="github" name="openxt/meta-openxt-haskell-platform" path="layers/meta-openxt-haskell-platform"/>
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" revision="master" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" revision="master" path="openxt/bordel"/>
   <project remote="github" name="openxt/fbtap" path="openxt/fbtap"/>
   <project remote="github" name="openxt/gene3fs" path="openxt/gene3fs"/>
   <project remote="github" name="openxt/icbinn" path="openxt/icbinn"/>

--- a/zeus.xml
+++ b/zeus.xml
@@ -20,6 +20,6 @@
   <project remote="github" name="openxt/meta-openxt-haskell-platform" path="layers/meta-openxt-haskell-platform"/>
   <project remote="github" name="openxt/xenclient-oe" path="layers/xenclient-oe"/>
 
-  <project remote="github" name="apertussolutions/bordel" revision="master" path="openxt/bordel"/>
+  <project remote="github" name="openxt/bordel" revision="master" path="openxt/bordel"/>
 </manifest>
 


### PR DESCRIPTION
Following the day of this commit, openxt-manifest and bordel were transferred under the OpenXT organization.

Reflect this change in the manifest.